### PR TITLE
Add `.npmrc` for legacy peer dependencies and update libraries

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@types/leaflet": "^1.9.21",
         "@zxing/browser": "^0.2.0",
+        "@zxing/library": "^0.23.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "country-data-list": "^1.6.2",
@@ -3271,6 +3272,21 @@
       },
       "peerDependencies": {
         "@zxing/library": "^0.22.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.23.0.tgz",
+      "integrity": "sha512-6fkkoFwP8CHxl6ugnPsj74PLJgX2iRv5zczGAyt5OBzQgxFhuhF0NCEc4t4OvSr8xAv2MRLlI0Iu9ZGDZQ2urA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
       }
     },
     "node_modules/@zxing/text-encoding": {
@@ -9543,6 +9559,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@types/leaflet": "^1.9.21",
     "@zxing/browser": "^0.2.0",
+    "@zxing/library": "^0.23.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "country-data-list": "^1.6.2",


### PR DESCRIPTION
This pull request includes the following changes:

- Adds a `.npmrc` file to enable the use of legacy peer dependencies in the project.
- Updates dependencies, including the integration of `@zxing/library`. 

These changes improve compatibility with package dependency management and maintain library consistency.